### PR TITLE
Tool_Path_Selection_Mods

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,6 +356,12 @@
 								<ul class="d-menu context drop-shadow" data-role="dropdown" data-duration="100" id="toolpathsmenu" data-toggle-element="#addJobBtn">
 									<li><a href="#" onclick="addJob(-1);"><span class="icon fa fa-plus"></span> Create a new Operation</a></li>
 								</ul>
+
+								<button id="remJobBtn" class="button small dark outline drop-shadow dropdown-toggle"><span class="icon fa fa-minus"></span> Rem <span class="selectCount" style="display: none;"> 0 </span></button>
+								<ul class="d-menu context drop-shadow" data-role="dropdown" data-duration="100" id="remtoolpathsmenu" data-toggle-element="#remJobBtn">
+									<li><a href="#" onclick="remJob(-1);"><span class="icon fa fa-plus"></span> Remove From Operation</a></li>
+								</ul>
+
 								<button class="button small dark outline drop-shadow" title="Generate GCODE" id="generatetpgcode" onclick="makeGcode();"><span class="fa fa-cubes icon"></span>Generate GCODE</button>
 								<button class="button small dark outline drop-shadow" title="Save GCODE" id="gcodesavebtn2" onclick="saveFile();"><span id="gcodeexporticon" class="fa fa-save icon fg-gray"></span></button>
 								<button class="button small dark outline drop-shadow" title="Preview GCODE" id="gcodeviewbtn2" onclick="previewFile();"><span id="gcodepreviewicon" class="fa fa-eye icon fg-gray"></span></button>

--- a/js/advanced-cam-doctree.js
+++ b/js/advanced-cam-doctree.js
@@ -186,9 +186,12 @@ function animateTree() {
     $('#addJobBtn').addClass('bg-green').addClass('fg-white').removeClass('disabled');
     $("#tpaddicon").addClass('fg-green')
     $(".selectCount").show();
+
     if (toolpathsInScene.length > 0) {
+      $('#remJobBtn').addClass('bg-green').addClass('fg-white').removeClass('disabled');
       $("#tpaddpath-dropdown").prop('disabled', false);
     }
+
   } else {
     $("#tpaddpathParent").prop('disabled', true).addClass('disabled');
     $("#tpaddicon").removeClass('fg-green')
@@ -197,7 +200,7 @@ function animateTree() {
     $("#tpaddpath").prop('disabled', true);
     // $('#floating-tpaddpath-btn').prop('disabled', true);
     // $('#floating-tpaddpath-btn').removeClass('success')
-    $('#addJobBtn').removeClass('bg-green').removeClass('fg-white').addClass('disabled');
+    $('#addJobBtn,#remJobBtn').removeClass('bg-green').removeClass('fg-white').addClass('disabled');
     $("#tpaddpath-dropdown").prop('disabled', true);
   }
 }

--- a/js/advanced-cam-tree.js
+++ b/js/advanced-cam-tree.js
@@ -21,6 +21,7 @@ function fillTree() {
   // $('#toolpathtreeheader').empty();
   $('#toolpathtree').empty();
   $('#toolpathsmenu').empty();
+  $('#remtoolpathsmenu').empty();
 
   // Default Menu
   var menuitem = `<li><a  href="#" onclick="addJob(-1);"><span class="fa fa-fw fa-plus"></span>Create a new operation...</a></li>`;
@@ -84,6 +85,7 @@ function fillTree() {
 
         toolp += `<button data-tooltip="tooltip" data-placement="bottom" title="Delete toolpath" class="tool-button alert" onclick="storeUndo(); toolpathsInScene.splice('` + i + `', 1); fillTree();"><i class="fa fa-times" aria-hidden="true"></i></button>
             <button data-tooltip="tooltip" data-placement="bottom" title="Configure toolpath" class="tool-button primary" onclick="setupJob(` + i + `);"><i class="fas fa-sliders-h"></i></button>
+            <button data-tooltip="tooltip" data-placement="bottom" title="Reselect toolpaths"   class="tool-button secondary" onclick="setSelectionFromToolPath(` + i + `)"><i class="fa fa-braille"></i></button>
             <span class="tally alert" style="display: none; margin-top: 6px;" id="toolpathSpinner`+i+`"><i class="fas fa-spinner fa-pulse"></i><small> calculating...</small></span>
                     </div>
                     </td>
@@ -103,6 +105,13 @@ function fillTree() {
       }
       var menuitem = `<li><a  href="#" onclick="addJob(` + i + `)">` + string + `</a></li>`;
       $('#toolpathsmenu').append(menuitem);
+
+
+      // append removal toolpath to menu
+      var string = `Rem from: ` + toolpathsInScene[i].name + `: ` + operation
+      if (string.length > 32) { string = string.substring(0, 32) + "..." }
+      var menuitem = `<li><a  href="#" onclick="remJob(` + i + `)">` + string + `</a></li>`;
+      $('#remtoolpathsmenu').append(menuitem);
 
     }
 

--- a/js/advanced-cam-viewer-mouse.js
+++ b/js/advanced-cam-viewer-mouse.js
@@ -138,3 +138,20 @@ function updateCloneMoves() {
     });
   }
 }
+
+// ------------------------------------------------------------------------------
+
+function getSelectedObjects(){
+  let selected = [];
+
+  for (i = 0; i < objectsInScene.length; i++) {
+    var object = objectsInScene[i]
+    object.traverse(function(child) {
+      if (child.userData.selected && child.userData.link) {
+        selected.push(child)
+      }
+    });
+  }
+
+  return selected;
+}

--- a/js/advanced-cam-viewer-select.js
+++ b/js/advanced-cam-viewer-select.js
@@ -7,27 +7,6 @@ var selectobj, arrow;
 var hoverShapesinScene = [];
 var mouseIsDown = false;
 
-function selectAll() {
-  for (i = 0; i < objectsInScene.length; i++) {
-    var obj = objectsInScene[i]
-    obj.traverse(function(child) {
-      if (child.type == "Line") {
-        child.userData.selected = true
-      }
-    });
-  }
-}
-
-function selectNone() {
-  for (i = 0; i < objectsInScene.length; i++) {
-    var obj = objectsInScene[i]
-    obj.traverse(function(child) {
-      if (child.type == "Line") {
-        child.userData.selected = false
-      }
-    });
-  }
-}
 
 function initMouseSelect() {
   selection = document.getElementById("selection");
@@ -45,28 +24,36 @@ function listeners() {
   // renderer.domElement.mouseup(mouseUp);
   // renderer.domElement.mousemove(mouseMove);
 
-  $('#selectAll').on('click', function() {
-    selectAll()
-  });
 
-  $('#selectNone').on('click', function() {
-    selectNone()
-  });
 
+  function selectAll_None(e) {
+    objectsInScene.map(a => a.children.map(b=>b.userData.selected = e.data.On_Off))
+    fillTree();
+  };
+
+  $('#selectAll').on('click', { On_Off: true}, selectAll_None); // Select All
+
+  $('#selectNone').on('click', {On_Off: false}, selectAll_None); // Select None
+
+  // function drf_inverse
   $('#selectInv').on('click', function() {
-    for (i = 0; i < objectsInScene.length; i++) {
-      var obj = objectsInScene[i]
-      obj.traverse(function(child) {
-        if (child.type == "Line") {
-          child.userData.selected = !child.userData.selected
-        }
-      });
-    }
+    objectsInScene.map(a => a.children.map(b=>b.userData.selected = !b.userData.selected))
+    fillTree();
   });
+
 
   $('#selectDel').on('click', function() {
-    storeUndo(true);
-    deleteSelectedObjects();
+    var x = getSelectedObjects();
+    if(x.length > 0){
+      var x = confirm("Are you sure you want to Delete the selected items?");
+      if (x) {
+        storeUndo(true);
+        deleteSelectedObjects();
+        return true;
+      } else {
+        return false;
+      }
+    }
   });
 }
 

--- a/js/advanced-cam.js
+++ b/js/advanced-cam.js
@@ -101,3 +101,105 @@ function addJob(id) {
   }
 
 }
+
+// -----------------------------------------------------------------------------------------------
+
+function remJob(id){
+  storeUndo(true);
+  $("#savetpgcode").addClass("disabled");
+  $("#exportGcodeMenu").addClass("disabled");
+
+  // animation to remove "doc" from Toolpath - helps user visualize what happened
+  var offset = $('#toolpathtree').offset()
+  $("#flyingdoc").css('top', offset.top);
+  $("#flyingdoc").css('left', offset.left);
+  $("#flyingdoc").fadeIn(200);
+
+  setTimeout(function() {
+    $("#flyingdoc").fadeOut(300);
+  }, 200);
+  $("#flyingdoc").animate({
+    left: '50%',
+    top: '50%'
+  }, 600);
+
+  var toolpath;
+  if (id > -1) { // Use Existing Toolpath
+      toolpath = toolpathsInScene[id];
+  }
+
+  selectedGeom = objectsInScene.map(a => a.children.map(b => b).filter(c => c.userData.selected)).reduce(a=>a);
+
+  selectedGeom.forEach(
+    function(e){
+      toolpath_IDS = toolpath.children.map(a => a.geometry.uuid)
+      toolpath.children.splice(toolpath_IDS.indexOf(e.geometry.uuid), 1) ;
+  });
+
+  if(toolpath.children.length == 0){
+    var message = `Toolpath Container is empty.  Would you like to remove it.`
+
+    Metro.dialog.create({
+      width: 500,
+      title: "Empty Toolpath.",
+      content: "<div>Toolpath container is empty.  Would you like to remove it?</div>",
+      actions: [{
+          caption: "<i class=\"far fa-fw fa-save\"></i>Remove",
+          cls: "js-dialog-close success",
+          onclick: function() {
+            toolpathsInScene.splice(id ,1);
+            fillTree();
+          }
+        },
+        {
+          caption: "<i class=\"far fa-fw fa-file\"></i>Keep",
+          cls: "js-dialog-close success",
+          onclick: function() {}
+        }
+      ]
+    });
+  }
+  else{
+    var message = `Toolpath container updated.`
+    Metro.toast.create(message, null, 4000, 'bg-green');
+  }
+
+  setTimeout(function() {
+    fillTree();
+    toolpathPreview(id);
+  }, 800); // launch modal
+
+}
+
+function setSelectionFromToolPath(id){
+  storeUndo(true);
+  $("#savetpgcode").addClass("disabled");
+  $("#exportGcodeMenu").addClass("disabled");
+
+  // animation to remove "doc" from Toolpath - helps user visualize what happened
+  var offset = $('#toolpathtree').offset()
+  $("#flyingdoc").css('top', offset.top);
+  $("#flyingdoc").css('left', offset.left);
+  $("#flyingdoc").fadeIn(200);
+
+  setTimeout(function() {
+    $("#flyingdoc").fadeOut(300);
+  }, 200);
+  $("#flyingdoc").animate({
+    left: '50%',
+    top: '50%'
+  }, 600);
+
+  var toolpath;
+  if (id > -1) { // Use Existing Toolpath
+      toolpath = toolpathsInScene[id];
+  }
+
+  GeoInToolPath = toolpath.children.map(a=>a.geometry.uuid);
+  ItemsToSelect = objectsInScene.map(a => a.children.map(b => GeoInToolPath.indexOf(b.geometry.uuid))).reduce(a=>a);
+  objectsInScene.map(a => a.children.map(b => b.userData.selected = (GeoInToolPath.indexOf(b.geometry.uuid) >= 0) ? true : false ));
+
+  setTimeout(function() {
+     fillTree();
+  }, 500); // launch modal
+}


### PR DESCRIPTION
These updates have provided additional selection features to do the following:

- Remove selections from a defined toolpath.
- Reselect items in the display window based on the toolpath items.
- Corrected the document selection options for the ALL, None, Invert buttons.
- Added a warning prior to deleting items from the document display window.

![Reselect_paths](https://user-images.githubusercontent.com/495322/229300000-92cd6a4b-05b2-4ce4-9aaf-89df5827319c.png)
![Remove_Selected](https://user-images.githubusercontent.com/495322/229300004-2ada7943-c5cf-46aa-9fe5-67b990905ceb.png)
 