### PR TITLE
Allow user to set spindel speed as percent of max.

### DIFF
--- a/js/advanced-cam-modal.js
+++ b/js/advanced-cam-modal.js
@@ -345,8 +345,8 @@ function setupJob(i) {
           </div>
         </td>
       </tr>
-      <tr class="inputlaser inputlaserraster">
-        <td>Laser: Power</td>
+      <tr class="inputcnc inputpocket inputplasma inputlaser inputlaserraster inputdrill inputdrillpeck">
+        <td>Laser Power / Spindle Speed</td>
         <td>
           <div class="input-addon">
             <span class="input-addon-label-left active-border"><i class="fas fa-tachometer-alt fa-fw"></i></span>


### PR DESCRIPTION
There is a bug where the "Laser: Power" option applies to any toolpath that uses the "S" command. This causes the spindle speed to be modified by the "Laser: power" option if one has been set. This change-set updates the "Laser: Power" option to be the "Laser Power / Spindle Speed" option and it applies to any toolpath that uses the "S" command.